### PR TITLE
Add convert rational to double

### DIFF
--- a/tests/Qtfy.QMath.Tests/BigRationalTests/ToDoubleTests.cs
+++ b/tests/Qtfy.QMath.Tests/BigRationalTests/ToDoubleTests.cs
@@ -5,6 +5,7 @@
 
 namespace Qtfy.QMath.Tests.BigRationalTests
 {
+    using System.Numerics;
     using NUnit.Framework;
 
     [TestOf(typeof(BigRational))]
@@ -43,6 +44,21 @@ namespace Qtfy.QMath.Tests.BigRationalTests
         {
             var actual = (double)(BigRational)expected;
             Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(1.0000000000000002, 4)]
+        [TestCase(1.0000000000000002, 3)]
+        [TestCase(1d, 2)]
+        [TestCase(1d, 1)]
+        [TestCase(1d, 0)]
+        [TestCase(1d, -1)]
+        [TestCase(0.99999999999999989, -2)]
+        [TestCase(0.99999999999999978, -3)]
+        [TestCase(0.99999999999999978, -4)]
+        public void CastToDoubleRounding(double expected, int shift)
+        {
+            var two54 = BigInteger.Pow(2, 54);
+            Assert.AreEqual(expected, (double)new BigRational(two54 + shift, two54));
         }
     }
 }


### PR DESCRIPTION
- added tests for rounding behavior (to nearest even number)
- back port `BigInteger.ToBitLength()` available in .NET 5.  